### PR TITLE
Fix error on regex

### DIFF
--- a/Mastodon_api.php
+++ b/Mastodon_api.php
@@ -46,7 +46,7 @@ class Mastodon_api {
 		}
 
 		if (count($data)) {
-			$parameters[CURLOPT_POSTFIELDS] = preg_replace('/([(%5B)]{1})[0-9]+([(%5D)]{1})/','$1$2',http_build_query($data));
+			$parameters[CURLOPT_POSTFIELDS] = preg_replace('/((%5B){1})[0-9]+((%5D){1})/','$1$2',http_build_query($data));
 		}
 
 		$url = $this->mastodon_url.$url;

--- a/Mastodon_api.php
+++ b/Mastodon_api.php
@@ -46,7 +46,7 @@ class Mastodon_api {
 		}
 
 		if (count($data)) {
-			$parameters[CURLOPT_POSTFIELDS] = preg_replace('/((%5B){1})[0-9]+((%5D){1})/','$1$2',http_build_query($data));
+			$parameters[CURLOPT_POSTFIELDS] = preg_replace('/(%5B)[0-9]+(%5D)/','$1$2',http_build_query($data));
 		}
 
 		$url = $this->mastodon_url.$url;


### PR DESCRIPTION
`[(%5B)]` and `[(%5D)]` were not picking up the patterns `%5B` and `%5D`. Instead, they just pick one character from the list: `(, %, 5, B, )` and `(, %, 5, D, )`. 

So `/([(%5B)]{1})[0-9]+([(%5D)]{1})/`
will match patterns like: `%23%25`
`%` from `[(%5B)]{1}`
`23%2` from `[0-9]+`
`5` from `[(%5D)]{1}`

`%235` happens to be #25 . 
The line: 
`preg_replace('/([(%5B)]{1})[0-9]+([(%5D)]{1})/','$1$2',http_build_query($data));`

Will convert something like: `text #25 more text` to `text %5 more text` beacuse:

Original text: `text #25 more text`
After http_build_query: `text %23%25 more text`
After preg_replace: `text %5 more text`.

The urlencoded %5 is wrong, so the API will complain with an error:

```
Rack::QueryParser::InvalidParameterError (invalid %-encoding (text+%5+more+text))
```

After removing [ and ] from the regex pattern, it will only match full sets of %5B and %5D (urlencoded `[` and `]`), so only text between those sets of characters will be removed.